### PR TITLE
add missing space between words

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 Copyright (c) Microsoft Corporation
 All rights reserved. 
 MIT License
-Permission is hereby granted, freeof charge, to any person obtaining a copy of this software and associateddocumentation files (the Software), to deal in the Software withoutrestriction, including without limitation the rights to use, copy, modify,merge, publish, distribute, sublicense, and/or sell copies of the Software, andto permit persons to whom the Software is furnished to do so, subject to thefollowing conditions:
+Permission is hereby granted, freeof charge, to any person obtaining a copy of this software and associated documentation files (the Software), to deal in the Software withoutrestriction, including without limitation the rights to use, copy, modify,merge, publish, distribute, sublicense, and/or sell copies of the Software, andto permit persons to whom the Software is furnished to do so, subject to thefollowing conditions:
  
 The above copyright notice andthis permission notice shall be included in all copies or substantial portionsof the Software.
  


### PR DESCRIPTION
a very simply typo fix: `associateddocumentation` --> `associated documentation`