### PR TITLE
Properly fix the license formatting

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
-[MS-DOS 1.25 & 2.0 Source]
-Copyright (c) Microsoft Corporation
-All rights reserved.
-MIT License
+[MS-DOS 1.25 & 2.0 Source]  
+Copyright (c) Microsoft Corporation  
+All rights reserved.  
+MIT License  
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the Software), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.


### PR DESCRIPTION
This fixes the line breaks on LICENSE.MD, at least the ones that weren't fixed properly in https://github.com/Microsoft/MS-DOS/commit/c665de90189930382843e8d98b47182e296e190e.

Consider checking out the excellent GFM document: https://github.github.com/gfm/ (relevant section [here](https://github.github.com/gfm/#hard-line-breaks))

---

Also "All Rights Reserved" then MIT doesn't really make much sense, perhaps a lawyer should take a look at that.