### PR TITLE
Change ’ to '

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ These are the same files [originally shared at the Computer History Museum on Ma
 All files within this repo are released under the [MIT (OSI) License]( https://en.wikipedia.org/wiki/MIT_License) as per the [LICENSE file](https://github.com/Microsoft/MS-DOS/blob/master/LICENSE.md) stored in the root of this repo.
 
 # Contribute!
-The source files in this repo are for historical reference and will be kept static, so please don’t send Pull Requests suggesting any modifications to the source files, but feel free to fork this repo and experiment 😊.  
+The source files in this repo are for historical reference and will be kept static, so please don't send Pull Requests suggesting any modifications to the source files, but feel free to fork this repo and experiment 😊.  
 
-If, however, you’d like to submit additional non-source content or modifications to non-source files (e.g., this README), please submit via PR, and we’ll review and consider.
+If, however, you'd like to submit additional non-source content or modifications to non-source files (e.g., this README), please submit via PR, and we'll review and consider.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).  For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Change ’ to '  as it is the most common way to use apostrophes
Reference: http://unicode.org/charts/PDF/U2000.pdf