### PR TITLE
[accessibility] replace e.g. with "for example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ All files within this repo are released under the [MIT (OSI) License]( https://e
 # Contribute!
 The source files in this repo are for historical reference and will be kept static, so please **don’t send** Pull Requests suggesting any modifications to the source files, but feel free to fork this repo and experiment 😊.  
 
-If, however, you’d like to submit additional non-source content or modifications to non-source files (e.g., this README), please submit via PR, and we’ll review and consider.
+If, however, you’d like to submit additional non-source content or modifications to non-source files (for example, this README), please submit via PR, and we’ll review and consider.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).  For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
e.g. being a Latin abbreviation can be confusing for folks for whom English (with all of its weird quirks) is not their first language.  There are better ways of saying "for example" (for example, for example) that will improve readability for all.

see also - https://insidegovuk.blog.gov.uk/2016/07/20/changes-to-the-style-guide-no-more-eg-and-ie-etc/