### PR TITLE
typo in README.pt-BR.md

### DIFF
--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -13,4 +13,4 @@ Os arquivos neste repositório são referências históricas e continuarão est�
 
 Se, no entanto, você quiser enviar conteúdos adicionais que não sejam conteúdos ou modificações no código fonte (como por exempo este LEIA-ME), por favor, envie via Pull Request e nós iremos revisar e considerar.
 
-Esse projeto tem adotado o [Código de Conduta para Código Aberto da Microsofit](https://opensource.microsoft.com/codeofconduct/). Para mais informações, veja o [FAQ do Código de Conduta](https://opensource.microsoft.com/codeofconduct/faq/) ou entre em contato com [opencode@microsoft.com](mailto:opencode@microsoft.com) para quaisquer questões ou comentários adicionais.
+Esse projeto tem adotado o [Código de Conduta para Código Aberto da Microsoft](https://opensource.microsoft.com/codeofconduct/). Para mais informações, veja o [FAQ do Código de Conduta](https://opensource.microsoft.com/codeofconduct/faq/) ou entre em contato com [opencode@microsoft.com](mailto:opencode@microsoft.com) para quaisquer questões ou comentários adicionais.


### PR DESCRIPTION
Fix typo in "Microsoft"