### PR TITLE
fixed typo in README.ko-KR.md

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -5,7 +5,7 @@
 이 파일들은 [원래 2014년 3월 25일 컴퓨터 역사 박물관에서 공유되었고]( http://www.computerhistory.org/atchm/microsoft-ms-dos-early-source-code/) 사람들이 찾기 쉽게 하고, 문헌 등에 인용 할 수 있게 하고, 초기 PC 운영체제에 관심이 있는 사람들의 분석과 실험을 위해 이 레포지토리에 (재)배포 되었습니다.
 
 # 라이선스
-여기에 있는 모든 파일들은 [LICENSE 파일에](https://github.com/Microsoft/MS-DOS/blob/master/LICENSE.md) 명시된 데로 [MIT (OSI) 라이선스]( https://en.wikipedia.org/wiki/MIT_License)로 배포됩니다.
+여기에 있는 모든 파일들은 [LICENSE 파일](https://github.com/Microsoft/MS-DOS/blob/master/LICENSE.md)에 명시된 데로 [MIT (OSI) 라이선스]( https://en.wikipedia.org/wiki/MIT_License)로 배포됩니다.
 
 # 기여하기!
 여기 있는 소스 코드 파일들은 역사적인 사료로서 수정되지 않을것이니, 제발 소스 코드 수정을 포함하는 Pull Request를 보내주시진 마시되, 포크해서 씹고 뜯고 맛보고 즐기세요.


### PR DESCRIPTION
 In English, the current document is highlighting 'in LICENSE file', not just 'LICENSE document'. So I changed the range of anchor text.