### PR TITLE
Small fixes in README.es.md: accents, making clearer sentences

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,16 +1,16 @@
 <img width="150" height="150" align="left" style="float: left; margin: 0 10px 0 0;" alt="MS-DOS logo" src="https://github.com/Microsoft/MS-DOS/blob/master/msdos-logo.png">   
 
 # Código Fuente de MS-DOS v1.25 y v2.0 
-Este repositorio contiene el código fuente original y binarios compilados para MS-DOS v1.25 y MS-DOS v2.0.
+Este repositorio contiene el código fuente original y los binarios compilados para MS-DOS v1.25 y MS-DOS v2.0.
 
-Estos son los mismos archivos [originalmente compartidos al Museo Histórico de Ordenadores en Marzo 25 de 2014]( http://www.computerhistory.org/atchm/microsoft-ms-dos-early-source-code/) y están siendo (re)publicados en este repositorio para que puedan ser encontrados mas fácilmente, referenciados en escritos y trabajos externos, y permitir la exploración y experimentación para aquellos interesados en sistemas operativos para PC tempranos.
+Estos son los mismos archivos [originalmente compartidos al Museo Histórico de Ordenadores en Marzo 25 de 2014]( http://www.computerhistory.org/atchm/microsoft-ms-dos-early-source-code/) y están siendo (re)publicados en este repositorio para que puedan ser encontrados más fácilmente, referenciados en escritos y trabajos externos y permitir la exploración y experimentación para aquellos interesados en los primeros sistemas operativos para PC.
 
 # Licencia 
 Todos los archivos contenidos en este repositorio fueron liberados bajo la [Licencia MIT (OSI)](https://es.wikipedia.org/wiki/Licencia_MIT) según el [archivo de Licencia](https://github.com/Microsoft/MS-DOS/blob/master/LICENSE.md) almacenado en la raíz de este repositorio.
 
 # ¡Contribuye!
-Los archivos fuente en este repositorio son para referencia histórica y permanecerán estáticos, así que por favor no envíes peticiones de cambio (pull requests) sugiriendo modificación alguna a los archivos de código fuente, pero sientete libre de bifurcar (fork) y experimentar 😊. 
+Los archivos fuente en este repositorio son para referencia histórica y permanecerán estáticos, así que por favor no envíes peticiones de cambio (pull requests) sugiriendo modificación alguna a los archivos de código fuente, pero siéntete libre de bifurcar (fork) y experimentar 😊. 
 
-Sin embargo, si deseas enviar contenido adicional que no sea código o modificaciones a archivos que no sean de código fuente (por ejemplo, este archivo README), envíe una petición (PR) y lo revisaremos y consideraremos.
+Sin embargo, si deseas enviar contenido adicional que no sea código o modificaciones a archivos que no sean de código fuente (por ejemplo, este archivo README), envía una petición (PR) y lo revisaremos y consideraremos.
 
-Este proyecto a adoptado el [Código de conducta de Microsoft Open Source (en inglés)](https://opensource.microsoft.com/codeofconduct/). Para mas información consulta las [Preguntas frecuentes del Código de Conducta (en inglés)](https://opensource.microsoft.com/codeofconduct/faq/) o contacta [opencode@microsoft.com](mailto:opencode@microsoft.com) con cualquier pregunta o comentario adicional.
+Este proyecto ha adoptado el [Código de conducta de Microsoft Open Source (en inglés)](https://opensource.microsoft.com/codeofconduct/). Para mas información consulta las [Preguntas frecuentes del Código de Conducta (en inglés)](https://opensource.microsoft.com/codeofconduct/faq/) o contacta [opencode@microsoft.com](mailto:opencode@microsoft.com) con cualquier pregunta o comentario adicional.


### PR DESCRIPTION
- correcciones en algunos acentos
- cambiando "a" por "ha" (ya que se trata del verbo haber)
- cambiando **"... interesados en sistemas operativos de PC tempranos"** por **"... interesados en los primeros sistemas operativos para PC"**, para que sea más entendible la oración.