### PR TITLE
Rewrite(Fix) Korean README file

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -1,13 +1,16 @@
 <img width="150" height="150" align="left" style="float: left; margin: 0 10px 0 0;" alt="MS-DOS logo" src="https://github.com/Microsoft/MS-DOS/blob/master/msdos-logo.png">   
 
-# MS-DOS v1.25 와 v2.0 소스 코드
-이 레포지토리는 MS-DOS v1.25와 v2.0의 원본 소스코드와 컴파일된 바이너리를 포함하고 있습니다.
-이 파일들은 [원래 2014년 3월 25일 컴퓨터 역사 박물관에서 공유되었고]( http://www.computerhistory.org/atchm/microsoft-ms-dos-early-source-code/) 사람들이 찾기 쉽게 하고, 문헌 등에 인용 할 수 있게 하고, 초기 PC 운영체제에 관심이 있는 사람들의 분석과 실험을 위해 이 레포지토리에 (재)배포 되었습니다.
+# MS-DOS v1.25, v2.0과 소스 코드
+본 저장소는 컴파일된 MS-DOS v1.25와 MS-DOS v2.0, 그리고 그 원본 소스코드를 저장한 저장소입니다.
+
+본 저장소의 파일들은 [2014년 3월 25일에 컴퓨터 역사 박물관에서 공개된 파일]( http://www.computerhistory.org/atchm/microsoft-ms-dos-early-source-code/)과 동일한 파일입니다. 검색과 외부 문헌으로의 인용 등을 용이하게  위해서 본 저장소에 (재)배포되었으며, 초창기 PC 운영체제에 관심이 있는 사람들에게도 좋은 분석과 실험의 기회가 될 것입니다.
 
 # 라이선스
-여기에 있는 모든 파일들은 [LICENSE 파일에](https://github.com/Microsoft/MS-DOS/blob/master/LICENSE.md) 명시된 데로 [MIT (OSI) 라이선스]( https://en.wikipedia.org/wiki/MIT_License)로 배포됩니다.
+본 저장소의 모든 파일은 본 저장소의 [라이선스 파일](https://github.com/Microsoft/MS-DOS/blob/master/LICENSE.md)에 명시된 대로,  [MIT (OSI) License](https://github.com/Microsoft/MS-DOS/blob/master/LICENSE.md)를 따릅니다.
 
-# 기여하기!
-여기 있는 소스 코드 파일들은 역사적인 사료로서 수정되지 않을것이니, 제발 소스 코드 수정을 포함하는 Pull Request를 보내주시진 마시되, 포크해서 씹고 뜯고 맛보고 즐기세요.
-만약, 그러나, (이 README 파일 수정과 같은) 소스 코드에 영향을 미치지 않는 내용 추가나 변경은, Pull Request를 보내주시면, 우리가 검토하고 반영될 수도 있습니다.
-이 프로젝트는 [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)를 따릅니다. 더 많은 정보를 원하시면 [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)를 참고하거나 [opencode@microsoft.com](mailto:opencode@microsoft.com)으로 연락 주시기 바랍니다.
+# 본 프로젝트에 기여!
+본 저장소의 소스 파일들은 역사적인 의미를 가지고 있으므로, 수정되지 않을 것입니다. 부디 소스 코드에 대한 수정 Pull Request는 **보내지 말아주세요**. 대신, 본 저장소를 fork하여 이용해주세요😊
+
+하지만, 본 README와 같이 소스 코드와 관련되지 않은 내용을 추가하거나, 혹은 수정하고 싶은 경우 PR로 제출해주세요. 해당 PR은 검토 후 반영 될 수도 있습니다.
+
+본 프로젝트는 [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)를 따르고 있습니다. 더 많은 정보는 [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)에서 확인할 수 있으며, 추가적인 질문 및 의견은[opencode@microsoft.com](mailto:opencode@microsoft.com)로 연락 부탁드립니다. 


### PR DESCRIPTION
Previous versions of Korean README contains word spacing errors, also  non-official phrases.
Since this repository is important, we should fix it :)